### PR TITLE
Clarify language design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# Dancecode
-Proposal for a programming language based on interpretive dance concepts
+# ChoreLang
+
+ChoreLang is a proposal for a new compiled programming language inspired by the elegance of interpretive dance. Programs in ChoreLang aim to be clear, expressive performances that transform data as gracefully as dancers move to music.
+
+## Highlights
+
+* **Native Compilation** - Generates small binaries that run on multiple targets with minimal runtime overhead.
+* **Concurrent by Design** - Leverages Go's concurrency primitives for effortless parallelism.
+* **Python Flexibility, Scala Precision & Go Clarity** - Combines dynamic constructs with a robust type system and straightforward tooling for readable code.
+* **First-Class AI APIs** - OpenAI and Ollama integrations are part of the standard library, allowing AI calls without extra packages.
+* **Loud, Fast Failures** - Errors surface immediately with detailed diagnostics so both humans and agents know exactly what went wrong.
+* **Unified File System API** - Cross-platform file operations are built in, including secure sandboxing for agent-oriented programs.
+* **Native Key-Value Store** - Table-like data structures reminiscent of Lua tables come built in for lightweight storage.
+* **Fast API Discovery** - Tooling can auto-discover available APIs (local or remote) and generate stubs for quick prototyping.
+* **Advanced Regex Engine** - Pattern matching with unreasonably powerful regular expressions is part of the standard library.
+* **Rich Standard Library** - Includes JSON parsing, HTTP utilities, and process control for everyday scripting.
+* **Dance Diagrams** - Use `chore chart file.dance` to generate mermaid charts that illustrate program flow.
+* **Built-In Linter** - `chore lint` keeps code elegant and consistent.
+* **Stage Package Manager** - Install plugins and libraries with `chore stage`.
+* **Scripting & REPL** - `chore run` executes scripts directly and `chore repl` provides an interactive shell.
+
+Detailed specifications for each highlight are available in the
+[docs](docs/) directory.
+
+## Getting Started
+
+ChoreLang is currently in the design phase. The toolchain is planned to be written in Go for ease of distribution. When ready, you will be able to install the compiler and runtime tools with a single command and begin dancing with code immediately.
+
+The language favors immediate feedback. Compilation and runtime errors are presented clearly and highlight the exact file and line so you can fix missteps without missing a beat.
+
+```
+# install chorelang (placeholder)
+$ chore install
+
+# run a script
+$ chore run hello.dance
+```
+
+### Example
+
+```chorelang
+sway i from 0 to 3 {
+    spin print("step", i)
+}
+```
+
+The example above shows a simple loop using dance-inspired keywords. Concurrency constructs let you orchestrate parallel movements easily, while the standard library grants direct access to OpenAI and Ollama for language model interactions. File operations and API discovery follow the same pattern, so every part of your program feels consistent and choreographed.
+
+## Technical Specification
+
+A detailed specification describing syntax, concurrency, and AI integrations lives in [TECH_SPEC.md](TECH_SPEC.md). The spec outlines how programs flow like choreography and how the compiler will be implemented.
+
+Stay tuned and join the conversation as we build a language where code truly dances.

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -1,0 +1,136 @@
+# ChoreLang Technical Specification
+
+This document describes the proposed design of ChoreLang. The language draws inspiration from interpretive dance, aiming for expressive syntax and rhythmic concurrency. Implementation details may evolve, but the goals remain: clarity, elegance, and first-class AI capabilities.
+
+## 1. Language Goals
+
+1. Produce small, cross-platform binaries.
+2. Embrace concurrency as a core construct using Go-like goroutines and channels.
+3. Combine Python-like flexibility, Scala-like precision, and Go-style clarity in a concise, statically typed language.
+4. Provide native access to OpenAI and Ollama APIs for AI-driven applications.
+5. Include a unified file system API for cross-platform development and secure sandboxing.
+6. Fail fast with clear diagnostics so developers and agents quickly see where problems occur.
+7. Ship a native key-value store reminiscent of Lua tables for flexible, lightweight data structures.
+8. Provide an advanced regular expression and pattern matching engine in the standard library.
+9. Support a scripting mode with a built-in REPL for rapid experimentation.
+## 2. Syntax Overview
+
+ChoreLang uses dance-inspired keywords to make code feel fluid:
+
+```chorelang
+sway i from 0 to 10 {
+    spin print(i)
+}
+```
+
+- `sway` acts like a `for` loop.
+- `spin` calls a function.
+
+Pattern matching and generics borrow from Scala:
+
+```chorelang
+dance result = match item {
+    when Note(n): flow process_note(n)
+    when Rest(): flow handle_rest()
+}
+```
+
+## 3. Concurrency Model
+
+ChoreLang compiles down to Go and retains goroutines and channels:
+
+```chorelang
+flow channel<int> steps
+start sway i from 0 to 3 {
+    send steps <- i
+}
+start sway step from steps {
+    spin print("step", step)
+}
+```
+
+- `start` launches a concurrent dancer (goroutine).
+- `flow` declares a channel.
+- `send` transmits values.
+
+## 4. Standard Library AI Support
+
+ChoreLang bundles clients for the OpenAI and Ollama APIs. Authentication keys can be provided through environment variables or configuration files. Sample usage:
+
+```chorelang
+flow ai = openai.client(api_key)
+dance resp = ai.complete("Write a short poem about dance")
+```
+
+Calling these APIs should feel as seamless as any other standard library call.
+
+## 5. File System and API Discovery
+
+ChoreLang includes a cross-platform file system module that abstracts away OS differences. By default, file access is sandboxed so agents can operate safely. The same module provides a discovery mechanism that scans available APIs (both local services and network endpoints) and generates bindings automatically.
+
+```chorelang
+flow fs = chore.fs()
+dance content = fs.read("poem.txt")
+```
+
+Discovered APIs can be imported using a single command:
+
+```shell
+$ chore discover http://localhost:3000
+```
+
+The compiler will generate stubs so you can call these APIs just like any other library.
+
+## 6. Key-Value Store and Pattern Matching
+
+ChoreLang's standard library includes a native key-value store inspired by Lua tables. These tables can hold mixed types and are optimized for performance so small data sets can be stored without external dependencies.
+
+Powerful regular expression handling is integrated directly into the language runtime. Patterns compile at build time when possible, and matching functions provide expressive captures and replacements.
+
+```chorelang
+dance t = chore.table()
+t["name"] = "step"
+if t["name"] =~ /st.+/ {
+    spin print("matched")
+}
+```
+
+The goal is to make common data manipulation and searching simple and fast without sacrificing elegance.
+## 7. Scripting Mode and REPL
+
+ChoreLang can execute scripts with `chore run` or open an interactive shell via `chore repl`. Modules load on demand so you can prototype quickly before compiling to a binary.
+
+## 8. Dance Diagrams
+
+ChoreLang treats every program as a choreography that can be visualized. The CLI provides a `chore chart` command (or `file.dance --chart`) that outputs a Mermaid diagram outlining each step of execution. These diagrams help developers and agents quickly grasp how data flows through the program.
+
+## 9. Compiler and Tooling
+
+The compiler is planned to be written in Go. It will translate ChoreLang source to Go code, then leverage the Go toolchain for optimized binaries. Compilation errors are reported with full file and line information so problems can be corrected quickly. The toolchain includes:
+
+- **chore build**: Compile sources to a native executable.
+- **chore test**: Run tests.
+- **chore deploy**: Package and distribute your application.
+- **chore run**: Execute `.dance` files without compiling.
+- **chore repl**: Start an interactive shell.
+- **chore chart**: Generate Mermaid diagrams from `.dance` files to visualize execution.
+- **chore lint**: Enforce elegant style and highlight potential missteps.
+- **chore stage**: Fetch libraries and plugins from the shared Stage repository.
+
+## 10. Implementation Roadmap
+
+1. **Prototype Parser and Lexer** – Define the syntax and create a translator to Go.
+2. **Concurrency Primitives** – Implement goroutine and channel mappings.
+3. **AI API Modules** – Integrate OpenAI and Ollama libraries with idiomatic wrappers.
+4. **Standard Library** – Provide utilities for file IO, networking, and basic data structures.
+5. **IDE Support and Visual Studio** – Develop the "Studio" environment to visualize programs as choreography.
+6. **Script Runner & REPL** – Implement `chore run` and an interactive shell for quick experimentation.
+
+## 11. Future Ideas
+
+- Live-coded choreography for interactive performances.
+- Advanced visualization tools that render real-time dance animations.
+- Community-driven extensions distributed through the Stage repository.
+
+ChoreLang invites developers to craft applications as if directing a performance. By blending practical tooling with artistic inspiration, it aims to make coding a graceful and enjoyable experience.
+

--- a/docs/advanced-regex-engine.md
+++ b/docs/advanced-regex-engine.md
@@ -1,0 +1,5 @@
+# Advanced Regex Engine
+
+ChoreLang ships with an expressive regular expression engine. Patterns compile
+at build time when possible, providing efficient searches. The API exposes rich
+captures, replacements, and callbacks for complex text processing.

--- a/docs/ai-apis.md
+++ b/docs/ai-apis.md
@@ -1,0 +1,5 @@
+# First-Class AI APIs
+
+OpenAI and Ollama clients live in the standard library. Developers can invoke
+language models without installing extra packages. Authentication comes from
+environment variables or configuration files.

--- a/docs/built-in-linter.md
+++ b/docs/built-in-linter.md
@@ -1,0 +1,5 @@
+# Built-In Linter
+
+`chore lint` enforces style conventions and warns about potential mistakes.
+It integrates with the compiler to catch issues early, ensuring every project
+maintains the elegance ChoreLang promotes.

--- a/docs/concurrent-by-design.md
+++ b/docs/concurrent-by-design.md
@@ -1,0 +1,5 @@
+# Concurrent by Design
+
+Concurrency is woven into ChoreLang using goroutines and channels, mirroring
+Go's model. Any function can be launched with `start`, and channels coordinate
+data between routines. This allows programs to scale without complex threading.

--- a/docs/dance-diagrams.md
+++ b/docs/dance-diagrams.md
@@ -1,0 +1,5 @@
+# Dance Diagrams
+
+`chore chart` produces Mermaid diagrams from `.dance` files. These charts
+illustrate the flow of concurrent dancers (goroutines) and data. They help
+visualize program logic for both developers and AI assistants.

--- a/docs/fast-api-discovery.md
+++ b/docs/fast-api-discovery.md
@@ -1,0 +1,5 @@
+# Fast API Discovery
+
+Tooling can scan running services or remote endpoints and automatically
+generate stubs for them. This allows quick integration with new APIs and makes
+agents aware of available capabilities without manual configuration.

--- a/docs/flexibility-precision-clarity.md
+++ b/docs/flexibility-precision-clarity.md
@@ -1,0 +1,3 @@
+# Python Flexibility, Scala Precision & Go Clarity
+
+ChoreLang blends the best aspects of these languages. It encourages quick experimentation like Python, borrows Scala's precise type system and pattern matching, and keeps everything readable with Go's straightforward style. The result is a dynamic yet safe language where elegance never obscures intent.

--- a/docs/go-style-clarity.md
+++ b/docs/go-style-clarity.md
@@ -1,0 +1,5 @@
+# Go-style Clarity
+
+ChoreLang values readability. The syntax is concise, imports are explicit, and
+the tooling avoids unnecessary complexity. Error handling uses straightforward
+patterns instead of exceptions, keeping code easy to follow.

--- a/docs/key-value-store.md
+++ b/docs/key-value-store.md
@@ -1,0 +1,5 @@
+# Native Key-Value Store
+
+ChoreLang features table-like structures that can store any type. These tables
+behave similarly to Lua tables with map and array semantics. They reside in the
+standard library, removing the need for external databases in small projects.

--- a/docs/loud-failures.md
+++ b/docs/loud-failures.md
@@ -1,0 +1,5 @@
+# Loud, Fast Failures
+
+Compilation and runtime errors provide detailed context: file, line, and a clear
+description. Warnings encourage best practices, while the CLI surfaces problems
+immediately so mistakes are corrected before deployment.

--- a/docs/native-compilation.md
+++ b/docs/native-compilation.md
@@ -1,0 +1,6 @@
+# Native Compilation
+
+ChoreLang compiles directly to small, self-contained binaries. The compiler
+translates ChoreLang source to Go, then leverages the Go toolchain for
+cross-platform builds. Binaries ship with minimal runtime requirements so
+deployments stay lightweight.

--- a/docs/scripting-and-repl.md
+++ b/docs/scripting-and-repl.md
@@ -1,0 +1,3 @@
+# Scripting and REPL
+
+ChoreLang supports a fast edit-run cycle. Use `chore run file.dance` to execute scripts directly or `chore repl` for an interactive session. Modules load with a simple `use` statement, making it practical for quick utilities and automation.

--- a/docs/stage-package-manager.md
+++ b/docs/stage-package-manager.md
@@ -1,0 +1,5 @@
+# Stage Package Manager
+
+The `chore stage` command downloads and installs libraries and plugins from the
+Stage repository. Packages define their steps in a manifest, making it simple to
+extend the language with community contributions.

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -1,0 +1,3 @@
+# Standard Library
+
+The standard library covers everyday scripting needs: JSON and YAML parsing, HTTP clients, file utilities, and a lightweight process API. Together with the package manager, it provides batteries-included functionality for building modern tools.

--- a/docs/unified-file-system-api.md
+++ b/docs/unified-file-system-api.md
@@ -1,0 +1,5 @@
+# Unified File System API
+
+A built-in module abstracts OS differences and provides secure sandboxing for
+agent-based programs. Functions cover common tasks like reading, writing, and
+walking directories with identical behavior on every platform.


### PR DESCRIPTION
## Summary
- combine flexibility, precision, and clarity highlight in README
- rename doc to `flexibility-precision-clarity.md`
- update language goals in TECH_SPEC

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68538fa895088329a8a45457a59948ed